### PR TITLE
🧪 [testing improvement] Add tests for empty domains in LegoJob.execute

### DIFF
--- a/files/lets-encrypt/scala-script/src/test/scala/com/kuba86/letsEntryptScript/RenewSpec.scala
+++ b/files/lets-encrypt/scala-script/src/test/scala/com/kuba86/letsEntryptScript/RenewSpec.scala
@@ -44,4 +44,18 @@ class RenewSpec extends FunSuite {
     assertEquals(renew.actionName, "renew")
     assertEquals(renew.actionArgs, Seq("renew", "--no-random-sleep", "--days", "15"))
   }
+
+  test("Renew.execute should return error when domains are empty") {
+    val emptyOptions = options.copy(certificate = Certificate(certDomains = ""))
+    val renewEmpty   = new Renew(emptyOptions)
+    val result       = renewEmpty.execute()
+    assertEquals(result, Left(CertError.UnspecifiedError("", "No domains provided")))
+  }
+
+  test("Renew.execute should return error when domains are whitespace only") {
+    val whitespaceOptions = options.copy(certificate = Certificate(certDomains = "   "))
+    val renewWhitespace   = new Renew(whitespaceOptions)
+    val result            = renewWhitespace.execute()
+    assertEquals(result, Left(CertError.UnspecifiedError("", "No domains provided")))
+  }
 }


### PR DESCRIPTION
🎯 What: Untested error path for empty domains in LegoJob.execute.
📊 Coverage: Added tests for empty string and whitespace-only string for certDomains.
✨ Result: Improved test coverage for LegoJob error handling.

---
*PR created automatically by Jules for task [1189121383273454391](https://jules.google.com/task/1189121383273454391) started by @kuba86*