### PR TITLE
⚡ Cache tailscale status output in 10-tailscale.sh

### DIFF
--- a/files/tailscale/10-tailscale.sh
+++ b/files/tailscale/10-tailscale.sh
@@ -10,20 +10,20 @@ is_service_active() {
   return $?
 }
 
-is_tailscale_ip_null() {
-  local tailscale_ip=$(tailscale status --json | jq -r .Self.TailscaleIPs[0])
-  [[ "$tailscale_ip" == "null" ]]
-  return $?
-}
-
 if ! is_in_path "tailscale"; then
   echo "tailscale not in path"
 elif ! is_service_active "tailscaled.service"; then
   echo "tailscaled.service not active"
-elif is_tailscale_ip_null; then
-  echo "Tailscale IP is null - device may not be connected to the tailnet"
 else
-  export TAILSCALE_IP=$(tailscale status --json | jq -r .Self.TailscaleIPs[0])
-  export TAILSCALE_SHORT_DOMAIN=$(tailscale status --json | jq -r .Self.HostName)
-  export TAILSCALE_FULL_DOMAIN=$(tailscale status --json | jq -r .CertDomains[])
+  tailscale_status=$(tailscale status --json)
+  tailscale_ip=$(echo "$tailscale_status" | jq -r .Self.TailscaleIPs[0])
+  if [[ "$tailscale_ip" == "null" ]]; then
+    echo "Tailscale IP is null - device may not be connected to the tailnet"
+  else
+    export TAILSCALE_IP="$tailscale_ip"
+    export TAILSCALE_SHORT_DOMAIN=$(echo "$tailscale_status" | jq -r .Self.HostName)
+    export TAILSCALE_FULL_DOMAIN=$(echo "$tailscale_status" | jq -r .CertDomains[])
+  fi
+  unset tailscale_status
+  unset tailscale_ip
 fi


### PR DESCRIPTION
💡 **What:** Optimized `files/tailscale/10-tailscale.sh` by caching the output of `tailscale status --json` in a local variable.

🎯 **Why:** The script previously executed `tailscale status --json` up to four times to check if the IP was null and then to extract various fields (IP, short domain, full domain). As this script is intended to be sourced via `/etc/profile.d/`, redundant command executions can noticeably delay shell login.

📊 **Measured Improvement:**
- **Baseline:** 4 calls to `tailscale status` for a successful connection.
- **After Optimization:** 1 call to `tailscale status`.
- **Latency reduction:** The overhead of three additional `tailscale` process forks and JSON parsing operations was eliminated. In mock benchmarks, the call count was reduced by 75% for the successful connection path.

---
*PR created automatically by Jules for task [9263820477884586911](https://jules.google.com/task/9263820477884586911) started by @kuba86*