### PR TITLE
🧹 ntfy: uncomment service restart handler triggers

### DIFF
--- a/playbooks/ntfy.yaml
+++ b/playbooks/ntfy.yaml
@@ -76,7 +76,7 @@
         mode: "0640"
       become: "{{ calculated_become }}"
       register: systemd_podman_quadlet_output
-#      notify: Restart service
+      notify: Restart service
     
     - name: ntfy | Ensure data directories exist
       ansible.builtin.file:
@@ -88,7 +88,7 @@
       loop: "{{ ntfy_directories }}"
       become: "{{ calculated_become }}"
       register: ntfy_directories_output
-#      notify: Restart service
+      notify: Restart service
 
     - name: ntfy | Restore ntfy data from restic backup
       ansible.builtin.command:
@@ -108,7 +108,7 @@
           - "security.selinux"
       become: "{{ calculated_become }}"
       when: ntfy_restore_backup
-#      notify: Restart service
+      notify: Restart service
     
     - name: ntfy | copy server configuration
       ansible.builtin.template:
@@ -119,7 +119,7 @@
         mode: "0640"
       become: "{{ calculated_become }}"
       register: ntfy_config_output
-#      notify: Restart service
+      notify: Restart service
   
   handlers:
     - name: Restart service


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was commented out 'notify: Restart service' triggers in the `playbooks/ntfy.yaml` file.
💡 **Why:** This improves maintainability by ensuring that the `ntfy` service is automatically restarted whenever its configuration, container definition, or data directories are modified. This keeps the service state in sync with the managed infrastructure.
✅ **Verification:** 
- Used `grep` to confirm all four instances were correctly uncommented.
- Validated YAML syntax using `ruby -e "require 'yaml'; YAML.load_file('playbooks/ntfy.yaml')"`.
- Confirmed indentation matches the surrounding tasks (6-space indent for the `notify` keyword).
✨ **Result:** The `ntfy` service now correctly reacts to configuration changes and data restorations by restarting, ensuring consistency between the host state and the running service.

---
*PR created automatically by Jules for task [6874011235064170639](https://jules.google.com/task/6874011235064170639) started by @kuba86*