### PR TITLE
🔒 [security fix] Hardening SSH Root Login configuration

### DIFF
--- a/playbooks/users.yaml
+++ b/playbooks/users.yaml
@@ -31,6 +31,7 @@
       ansible.builtin.copy:
         content: |
           PasswordAuthentication no
+          PermitRootLogin prohibit-password
           AllowUsers core user root emergency
           AuthorizedKeysFile .ssh/authorized_keys.d/ansible
         dest: /etc/ssh/sshd_config.d/60-common.conf

--- a/setup-systemd-container.txt
+++ b/setup-systemd-container.txt
@@ -8,7 +8,7 @@ chmod 600 /root/.ssh/authorized_keys.d/ansible && \
 echo "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDrCYkPBxz517aBYDNI/VwiyxX10M5cXvt1FbUa04qdr 2024-12-26-ansible" > /root/.ssh/authorized_keys.d/ansible && \
 echo "PasswordAuthentication no" > /etc/ssh/sshd_config.d/ansible.conf && \
 echo "AllowUsers core root" >> /etc/ssh/sshd_config.d/ansible.conf && \
-echo "PermitRootLogin yes" >> /etc/ssh/sshd_config.d/ansible.conf && \
+echo "PermitRootLogin prohibit-password" >> /etc/ssh/sshd_config.d/ansible.conf && \
 echo "authorizedkeysfile .ssh/authorized_keys .ssh/authorized_keys.d/ansible" >> /etc/ssh/sshd_config.d/ansible.conf && \
 chmod 600 /etc/ssh/sshd_config.d/ansible.conf && \
 systemctl restart sshd


### PR DESCRIPTION
# 🔒 Security Fix: Hardening SSH Root Login

## 🎯 What
This PR addresses a security vulnerability where `PermitRootLogin` was set to `yes` in certain SSH configuration snippets.

## ⚠️ Risk
Setting `PermitRootLogin yes` allows the root user to log in using a password (unless `PasswordAuthentication no` is also set). This increases the attack surface for brute-force and credential stuffing attacks targeting the most privileged account on the system.

## 🛡️ Solution
I have updated the following files to use `PermitRootLogin prohibit-password`:
- `setup-systemd-container.txt`: The script now configures SSH to allow root login only via public key authentication.
- `playbooks/users.yaml`: The Ansible playbook now explicitly includes `PermitRootLogin prohibit-password` in its generated SSH configuration to ensure consistent security across all managed hosts.

This change maintains necessary automation access (since keys are provided) while following security best practices.

## ✅ Verification
- Manually inspected the modified files to ensure correct syntax and logic.
- A code review was performed and confirmed the correctness of the fix.


---
*PR created automatically by Jules for task [9259831638654963875](https://jules.google.com/task/9259831638654963875) started by @kuba86*