### PR TITLE
🧹 Convert Gemini CLI playbook to Podman

### DIFF
--- a/files/gemini-cli/Containerfile
+++ b/files/gemini-cli/Containerfile
@@ -1,0 +1,4 @@
+FROM docker.io/node:22-alpine
+RUN npm install -g @google/gemini-cli
+WORKDIR /app
+ENTRYPOINT ["gemini"]

--- a/files/gemini-cli/gemini.sh
+++ b/files/gemini-cli/gemini.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Create config directory if it doesn't exist
+mkdir -p "$HOME/.config/gemini-cli"
+
+# Run the Gemini CLI container
+# We mount the home directory's gemini-cli config and the current working directory
+podman run --rm -it \
+  --name "gemini-cli-$(date +%s)" \
+  --volume "$HOME/.config/gemini-cli:/root/.config/gemini-cli:z" \
+  --volume "$PWD:/app:z" \
+  --workdir /app \
+  ${GEMINI_API_KEY:+--env GEMINI_API_KEY="$GEMINI_API_KEY"} \
+  gemini-cli:latest "$@"

--- a/playbooks/all.yaml
+++ b/playbooks/all.yaml
@@ -76,7 +76,7 @@
 - name: Playbooks | SftpGo
   ansible.builtin.import_playbook:
 
-- name: Playbooks | Gemini CLI #TODO: convert to podman
+- name: Playbooks | Gemini CLI
   ansible.builtin.import_playbook: gemini-cli.yaml
 
 - name: Playbooks | Let's Encrypt

--- a/playbooks/gemini-cli.yaml
+++ b/playbooks/gemini-cli.yaml
@@ -5,7 +5,7 @@
     - "../inventories/prod/secret_vars/all.yaml"
 
   pre_tasks:
-    - name: Gather per-host secret files
+    - name: Gemini CLI | Gather per-host secret files
       ansible.builtin.include_vars:
         file: "{{ item }}"
       loop:
@@ -13,15 +13,70 @@
       when: lookup('ansible.builtin.fileglob', item) | length > 0
 
   tasks:
+    - name: Gemini CLI | variables (detect container)
+      ansible.builtin.set_fact:
+        run_as_root: "{{ ansible_facts['virtualization_tech_guest'] | default([]) | intersect(['lxc', 'container']) | length > 0 }}"
 
-    - name: Gemini CLI | Gemini CLI
+    - name: Gemini CLI | variables (compute once, reuse everywhere)
+      ansible.builtin.set_fact:
+        file_owner: "{{ 'root' if run_as_root else main_user }}"
+        file_group: "{{ 'root' if run_as_root else main_user }}"
+        bin_dir: "{{ '/usr/local/bin' if run_as_root else '/home/' ~ main_user ~ '/bin' }}"
+        calculated_become: "{{ run_as_root }}"
+
+    - name: Gemini CLI | Info about running user
+      ansible.builtin.debug:
+        msg:
+          - "Run as root: {{ run_as_root }}"
+          - "Bin dir: {{ bin_dir }}"
+          - "User: {{ file_owner }}"
+          - "Group: {{ file_group }}"
+          - "Become: {{ calculated_become }}"
+
+    - name: Gemini CLI | Create files directory
+      ansible.builtin.file:
+        path: "{{ '/etc/gemini-cli' if run_as_root else '/home/' ~ main_user ~ '/.config/gemini-cli-build' }}"
+        state: directory
+        owner: "{{ file_owner }}"
+        group: "{{ file_group }}"
+        mode: "0755"
+      become: "{{ calculated_become }}"
+
+    - name: Gemini CLI | Copy Containerfile
+      ansible.builtin.copy:
+        src: ../files/gemini-cli/Containerfile
+        dest: "{{ '/etc/gemini-cli/Containerfile' if run_as_root else '/home/' ~ main_user ~ '/.config/gemini-cli-build/Containerfile' }}"
+        owner: "{{ file_owner }}"
+        group: "{{ file_group }}"
+        mode: "0644"
+      become: "{{ calculated_become }}"
+      register: containerfile_output
+
+    - name: Gemini CLI | Build Podman Image
+      containers.podman.podman_image:
+        name: gemini-cli
+        tag: latest
+        path: "{{ '/etc/gemini-cli' if run_as_root else '/home/' ~ main_user ~ '/.config/gemini-cli-build' }}"
+        force: "{{ containerfile_output.changed }}"
+      become: "{{ calculated_become }}"
+
+    - name: Gemini CLI | Deploy wrapper script
+      ansible.builtin.copy:
+        src: ../files/gemini-cli/gemini.sh
+        dest: "{{ bin_dir }}/gemini"
+        owner: "{{ file_owner }}"
+        group: "{{ file_group }}"
+        mode: "0755"
+      become: "{{ calculated_become }}"
+
+    - name: Gemini CLI | Remove legacy global npm installation
       ansible.builtin.shell: |
-        set -euo pipefail
-        IFS=$'\n\t'
-
-        npm install -g @google/gemini-cli
+        if npm list -g @google/gemini-cli &>/dev/null; then
+          npm uninstall -g @google/gemini-cli
+        fi
       args:
         executable: /usr/bin/bash
       become: true
       when:
         - ansible_pkg_mgr in ['atomic_container', 'dnf', 'dnf5']
+      changed_when: false


### PR DESCRIPTION
This change migrates the Gemini CLI deployment to use Podman containers, following the repository's established patterns. It includes the necessary Containerfile, a wrapper script for host-side execution, and a refactored Ansible playbook.

---
*PR created automatically by Jules for task [8136022612718369579](https://jules.google.com/task/8136022612718369579) started by @kuba86*