### PR TITLE
🧪 Add unit test for LegoJob execution process failure

### DIFF
--- a/files/lets-encrypt/scala-script/src/main/scala/LegoJob.scala
+++ b/files/lets-encrypt/scala-script/src/main/scala/LegoJob.scala
@@ -24,6 +24,16 @@ abstract class LegoJob {
 
   private val daysPattern: Regex = """The certificate expires in (\d+) days""".r
 
+  protected def runCommand(command: Seq[String], env: Map[String, String]): os.CommandResult = {
+    os.proc(command)
+      .call(
+        cwd = os.pwd,
+        env = env,
+        stdout = os.Pipe,
+        stderr = os.Pipe
+      )
+  }
+
   def execute(): Either[CertError, CertOk] = {
     val domains: List[String] = certDomains.trim.split(" ").filter(_.nonEmpty).toList
     if (domains.isEmpty) {
@@ -59,13 +69,7 @@ abstract class LegoJob {
     )
 
     Try {
-      os.proc(legoCommand)
-        .call(
-          cwd = os.pwd,
-          env = env,
-          stdout = os.Pipe,
-          stderr = os.Pipe
-        )
+      runCommand(legoCommand, env)
     } match {
       case Success(result) =>
         result.err.trim() match {

--- a/files/lets-encrypt/scala-script/src/test/scala/com/kuba86/letsEntryptScript/RenewSpec.scala
+++ b/files/lets-encrypt/scala-script/src/test/scala/com/kuba86/letsEntryptScript/RenewSpec.scala
@@ -58,4 +58,20 @@ class RenewSpec extends FunSuite {
     val result            = renewWhitespace.execute()
     assertEquals(result, Left(CertError.UnspecifiedError("", "No domains provided")))
   }
+
+  test("Renew.execute should handle process execution failure (Exception)") {
+    class RenewThrows(options: RenewOptions) extends Renew(options) {
+      override protected def runCommand(command: Seq[String], env: Map[String, String]): os.CommandResult = {
+        throw new RuntimeException("Simulated process failure")
+      }
+    }
+
+    val renewFailure = new RenewThrows(options)
+    val result       = renewFailure.execute()
+
+    assertEquals(
+      result,
+      Left(CertError.UnspecifiedError("renew", "Exception: Simulated process failure"))
+    )
+  }
 }


### PR DESCRIPTION
🎯 **What:** `LegoJob.execute` lacked test coverage for underlying `os.proc` command failures.
📊 **Coverage:** Extracted `os.proc` execution to a protected `runCommand` method, allowing tests to simulate command failure (e.g. `java.io.IOException` or `os.SubprocessException`) by overriding it. A test case was added to `RenewSpec.scala` asserting that `Left(CertError.UnspecifiedError(...))` is returned when the execution fails.
✨ **Result:** Increased test suite robustness by effectively validating the `Failure` condition in the execute method's main `Try` block.

---
*PR created automatically by Jules for task [3890188682598721148](https://jules.google.com/task/3890188682598721148) started by @kuba86*