### PR TITLE
🔒 Fix permissive ntfy rate limiting

### DIFF
--- a/files/ntfy/server.yml
+++ b/files/ntfy/server.yml
@@ -276,14 +276,15 @@ enable-reservations: false
 # visitor-request-limit-burst: 60
 # visitor-request-limit-replenish: "5s"
 # visitor-request-limit-exempt-hosts: ""
-visitor-request-limit-burst: 60
+visitor-request-limit-burst: 10
 visitor-request-limit-replenish: "60s"
 
 # Rate limiting: Hard daily limit of messages per visitor and day. The limit is reset
 # every day at midnight UTC. If the limit is not set (or set to zero), the request
 # limit (see above) governs the upper limit.
 #
-# visitor-message-daily-limit: 0
+visitor-message-daily-limit: 1000
+
 
 # Rate limiting: Allowed emails per visitor:
 # - visitor-email-limit-burst is the initial bucket of emails each visitor has


### PR DESCRIPTION
🎯 **What:** Tightened HTTP request rate limiting configurations for the ntfy service in `files/ntfy/server.yml`.
⚠️ **Risk:** Permissive rate limiting settings, especially combined with `enable-login: true`, pose a risk of abuse, including brute-force attacks or overwhelming the server with excessive traffic from a single IP.
🛡️ **Solution:** Reduced `visitor-request-limit-burst` from 60 to 10 to restrict sudden request spikes, and uncommented and enforced a strict `visitor-message-daily-limit` of 1000.

---
*PR created automatically by Jules for task [3686096336312464399](https://jules.google.com/task/3686096336312464399) started by @kuba86*