### PR TITLE
🧹 [code health improvement] Refactor LegoJob execute method

### DIFF
--- a/files/lets-encrypt/scala-script/src/main/scala/LegoJob.scala
+++ b/files/lets-encrypt/scala-script/src/main/scala/LegoJob.scala
@@ -24,6 +24,40 @@ abstract class LegoJob {
 
   private val daysPattern: Regex = """The certificate expires in (\d+) days""".r
 
+  private def buildLegoCommand(domains: List[String], dnsResolverList: List[String]): Seq[String] = {
+    val domainFlags: List[String]      = domains.flatMap(d => Seq("--domains", d))
+    val dnsResolverFlags: List[String] = dnsResolverList.flatMap(s => Seq("--dns.resolvers", s))
+
+    val pathFlag: Seq[String]   = legoPath.map(v => Seq("--path", v)).getOrElse(Seq.empty)
+    val serverFlag: Seq[String] = legoServer.map(v => Seq("--server", v)).getOrElse(Seq.empty)
+
+    Seq(
+      "lego",
+      "--accept-tos",
+      "--email",
+      legoEmail,
+      "--dns",
+      dnsProvider
+    ) ++ pathFlag ++ serverFlag ++ domainFlags ++ dnsResolverFlags ++ actionArgs
+  }
+
+  private def parseResult(result: os.CommandResult, domain: String): Either[CertError, CertOk] = {
+    result.err.trim() match {
+      case stderr if stderr.contains("Server responded with a certificate.") =>
+        Right(CertOk.NewCertificate(domain))
+      case stderr if stderr.contains("The certificate expires in") =>
+        daysPattern.findFirstMatchIn(stderr) match {
+          case Some(m) =>
+            Right(CertOk.NoNeedForRenew(domain, Option(m.group(1).toInt)))
+          case None =>
+            Left(CertError.UnspecifiedError(domain, stderr))
+        }
+      case _ =>
+        error(s"Lego $actionName command failed with exit code: ${result.exitCode}")
+        Left(CertError.UnspecifiedError(domain, result.err.trim()))
+    }
+  }
+
   def execute(): Either[CertError, CertOk] = {
     val domains: List[String] = certDomains.trim.split(" ").filter(_.nonEmpty).toList
     if (domains.isEmpty) {
@@ -34,20 +68,7 @@ abstract class LegoJob {
 
     val dnsResolverList: List[String] = dnsServers.trim.split(" ").filter(_.nonEmpty).toList
 
-    val domainFlags: List[String]      = domains.flatMap(d => Seq("--domains", d))
-    val dnsResolverFlags: List[String] = dnsResolverList.flatMap(s => Seq("--dns.resolvers", s))
-
-    val pathFlag: Seq[String]   = legoPath.map(v => Seq("--path", v)).getOrElse(Seq.empty)
-    val serverFlag: Seq[String] = legoServer.map(v => Seq("--server", v)).getOrElse(Seq.empty)
-
-    val legoCommand: Seq[String] = Seq(
-      "lego",
-      "--accept-tos",
-      "--email",
-      legoEmail,
-      "--dns",
-      dnsProvider
-    ) ++ pathFlag ++ serverFlag ++ domainFlags ++ dnsResolverFlags ++ actionArgs
+    val legoCommand: Seq[String] = buildLegoCommand(domains, dnsResolverList)
 
     debug(s"Executing command: ${legoCommand.mkString(" ")}")
 
@@ -68,20 +89,7 @@ abstract class LegoJob {
         )
     } match {
       case Success(result) =>
-        result.err.trim() match {
-          case stderr if stderr.contains("Server responded with a certificate.") =>
-            Right(CertOk.NewCertificate(domains.head))
-          case stderr if stderr.contains("The certificate expires in") =>
-            daysPattern.findFirstMatchIn(stderr) match {
-              case Some(m) =>
-                Right(CertOk.NoNeedForRenew(domains.head, Option(m.group(1).toInt)))
-              case None =>
-                Left(CertError.UnspecifiedError(domains.head, stderr))
-            }
-          case _ =>
-            error(s"Lego $actionName command failed with exit code: ${result.exitCode}")
-            Left(CertError.UnspecifiedError(domains.head, result.err.trim()))
-        }
+        parseResult(result, domains.head)
       case Failure(exception) =>
         error(s"Lego $actionName command failed with exception: ${exception.getMessage}")
         Left(CertError.UnspecifiedError(actionName, s"Exception: ${exception.getMessage}"))


### PR DESCRIPTION
🎯 **What:** The `execute` method in `LegoJob.scala` was overly complex and handling multiple responsibilities (command construction, process execution, and error parsing).
💡 **Why:** Splitting this logic into distinct methods (`buildLegoCommand` and `parseResult`) significantly improves readability and maintainability by keeping the `execute` method focused entirely on orchestration. 
✅ **Verification:** Re-ran `scala-cli --power test files/lets-encrypt/scala-script`. Confirmed all existing functionality and tests continue to pass identically. 
✨ **Result:** A much cleaner, simpler `execute` method with isolated utility functions that are easier to reason about and independently test in the future.

---
*PR created automatically by Jules for task [17512130527093491133](https://jules.google.com/task/17512130527093491133) started by @kuba86*