### PR TITLE
🧹 Remove dead commented-out code in CryptPad config

### DIFF
--- a/files/cryptpad/config.js
+++ b/files/cryptpad/config.js
@@ -226,7 +226,6 @@ module.exports = {
      *  anything larger than this size will be rejected
      *  defaults to 20MB if no value is provided
      */
-    //maxUploadSize: 20 * 1024 * 1024,
     maxUploadSize: 20 * 1024 * 1024, // 20MB
 
     /*  Users with premium accounts (those with a plan included in their customLimit)
@@ -234,7 +233,6 @@ module.exports = {
      *  upload size as any other registered user.
      *
      */
-    //premiumUploadSize: 100 * 1024 * 1024,
     premiumUploadSize: 1024 * 1024 * 1024, // 1GB
 
     /* =====================


### PR DESCRIPTION
🎯 **What:** Removed redundant, commented-out configuration lines for `maxUploadSize` and `premiumUploadSize` in `files/cryptpad/config.js`.
💡 **Why:** Deleting commented-out code in configuration files reduces clutter since the actual value is set directly below it, improving readability and maintainability.
✅ **Verification:** Verified that `files/cryptpad/config.js` is still syntactically valid Javascript using `node -c`.
✨ **Result:** A cleaner and more maintainable configuration file for CryptPad.

---
*PR created automatically by Jules for task [1171682702847625843](https://jules.google.com/task/1171682702847625843) started by @kuba86*