### PR TITLE
🔒 Fix weak secret generation for Kanidm OAuth2 cookie secret

### DIFF
--- a/files/kanidm/provision_kanidm_oauth2.sh
+++ b/files/kanidm/provision_kanidm_oauth2.sh
@@ -27,6 +27,11 @@ if ! command -v kanidm >/dev/null 2>&1; then
   exit 1
 fi
 
+if ! command -v openssl >/dev/null 2>&1; then
+  echo "ERROR: 'openssl' command not found." >&2
+  exit 1
+fi
+
 # Split scopes string into array args
 read -r -a scopes_arr <<<"$scopes_str"
 
@@ -71,7 +76,7 @@ if [[ -z "${client_secret:-}" ]]; then
   exit 1
 fi
 
-cookie_secret="$(LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 32 || true)"
+cookie_secret="$(openssl rand -base64 32)"
 
 echo ""
 echo "cookie_domain: $domain"


### PR DESCRIPTION
🎯 **What:** The `provision_kanidm_oauth2.sh` script used a weak method (`tr` on `/dev/urandom` restricted to alphanumeric characters) to generate the `cookie_secret` for OAuth2 proxies.

⚠️ **Risk:** The previous method provided limited entropy (approximately 190 bits), which is lower than the recommended 256 bits for cryptographic secrets used in tools like `oauth2-proxy`. A predictable secret could potentially allow attackers to forge cookies.

🛡️ **Solution:** Replaced the weak secret generation with `openssl rand -base64 32`, which provides a cryptographically strong 256-bit entropy secret. Also added a check to ensure `openssl` is installed before running the script.

---
*PR created automatically by Jules for task [6649823407248736739](https://jules.google.com/task/6649823407248736739) started by @kuba86*