### PR TITLE
🧹 [refactor] Remove duplicate execute() method in LegoJob

### DIFF
--- a/files/lets-encrypt/scala-script/src/main/scala/LegoJob.scala
+++ b/files/lets-encrypt/scala-script/src/main/scala/LegoJob.scala
@@ -34,16 +34,7 @@ abstract class LegoJob {
       )
   }
 
-  def execute(): Either[CertError, CertOk] = {
-    val domains: List[String] = certDomains.trim.split(" ").filter(_.nonEmpty).toList
-    if (domains.isEmpty) {
-      error("No domains provided")
-      return Left(CertError.UnspecifiedError("", "No domains provided"))
-    }
-    debug(s"Domains: $domains")
-
-    val dnsResolverList: List[String] = dnsServers.trim.split(" ").filter(_.nonEmpty).toList
-
+  private def buildLegoCommand(domains: List[String], dnsResolverList: List[String]): Seq[String] = {
     val domainFlags: List[String]      = domains.flatMap(d => Seq("--domains", d))
     val dnsResolverFlags: List[String] = dnsResolverList.flatMap(s => Seq("--dns.resolvers", s))
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was a duplicate `execute()` method definition in `LegoJob.scala`.

💡 **Why:** This improves maintainability by removing redundant code and separating the concerns of building the command arguments from the actual process execution and result parsing.

✅ **Verification:** The refactoring was verified by manual inspection of the code structure in `LegoJob.scala` and ensuring that the public `execute()` method correctly delegates to the new `buildLegoCommand` helper. Existing unit tests in `RenewSpec.scala` that call `execute()` were reviewed to ensure they remain valid.

✨ **Result:** Improved code readability and eliminated a potential source of confusion or bugs caused by duplicate method definitions.

---
*PR created automatically by Jules for task [2944154466556625338](https://jules.google.com/task/2944154466556625338) started by @kuba86*