### PR TITLE
⚡ [remove redundant execute method in LegoJob]

### DIFF
--- a/files/lets-encrypt/scala-script/src/main/scala/LegoJob.scala
+++ b/files/lets-encrypt/scala-script/src/main/scala/LegoJob.scala
@@ -34,16 +34,7 @@ abstract class LegoJob {
       )
   }
 
-  def execute(): Either[CertError, CertOk] = {
-    val domains: List[String] = certDomains.trim.split(" ").filter(_.nonEmpty).toList
-    if (domains.isEmpty) {
-      error("No domains provided")
-      return Left(CertError.UnspecifiedError("", "No domains provided"))
-    }
-    debug(s"Domains: $domains")
-
-    val dnsResolverList: List[String] = dnsServers.trim.split(" ").filter(_.nonEmpty).toList
-
+  private def buildLegoCommand(domains: List[String], dnsResolverList: List[String]): Seq[String] = {
     val domainFlags: List[String]      = domains.flatMap(d => Seq("--domains", d))
     val dnsResolverFlags: List[String] = dnsResolverList.flatMap(s => Seq("--dns.resolvers", s))
 


### PR DESCRIPTION
💡 **What:** Refactored `LegoJob.scala` to rename a misnamed and redundant `execute` method to `buildLegoCommand`. Updated its signature to accept pre-processed domain and DNS resolver lists and removed redundant string splitting/validation logic.
🎯 **Why:** The code contained a logic error where two methods were named `execute`, one of which was intended to be a command builder. This redundant method also performed duplicate string operations that were already handled by the caller, leading to unnecessary allocations and processing.
📊 **Measured Improvement:** By removing redundant `trim()`, `split()`, and `filter()` operations on domain and DNS resolver strings, we reduce CPU cycles and memory allocations per execution. While minor in absolute terms for a job script, it ensures the code is logically correct and more efficient.

---
*PR created automatically by Jules for task [839101196696306643](https://jules.google.com/task/839101196696306643) started by @kuba86*