### PR TITLE
🧪 [RunSpec] Add test file for Run class

### DIFF
--- a/files/lets-encrypt/scala-script/src/main/scala/LegoJob.scala
+++ b/files/lets-encrypt/scala-script/src/main/scala/LegoJob.scala
@@ -34,16 +34,7 @@ abstract class LegoJob {
       )
   }
 
-  def execute(): Either[CertError, CertOk] = {
-    val domains: List[String] = certDomains.trim.split(" ").filter(_.nonEmpty).toList
-    if (domains.isEmpty) {
-      error("No domains provided")
-      return Left(CertError.UnspecifiedError("", "No domains provided"))
-    }
-    debug(s"Domains: $domains")
-
-    val dnsResolverList: List[String] = dnsServers.trim.split(" ").filter(_.nonEmpty).toList
-
+  private def buildLegoCommand(domains: List[String], dnsResolverList: List[String]): Seq[String] = {
     val domainFlags: List[String]      = domains.flatMap(d => Seq("--domains", d))
     val dnsResolverFlags: List[String] = dnsResolverList.flatMap(s => Seq("--dns.resolvers", s))
 

--- a/files/lets-encrypt/scala-script/src/test/scala/com/kuba86/letsEntryptScript/RunSpec.scala
+++ b/files/lets-encrypt/scala-script/src/test/scala/com/kuba86/letsEntryptScript/RunSpec.scala
@@ -1,0 +1,89 @@
+package com.kuba86.letsEntryptScript
+
+import com.kuba86.letsEntryptScript.model.*
+import munit.FunSuite
+
+class RunSpec extends FunSuite {
+  val options = RunOptions(
+    logLevel = "debug",
+    cloudflare = Cloudflare(
+      apiToken = "test-token",
+      pollingInterval = 10,
+      propagationTimeout = 200,
+      ttl = 60,
+      dnsProvider = "test-provider"
+    ),
+    certificate = Certificate(
+      certDomains = "example.com www.example.com"
+    ),
+    lego = Lego(
+      legoEmail = "test@example.com",
+      legoPath = Some("/tmp/lego"),
+      legoServer = Some("https://acme-staging-v02.api.letsencrypt.org/directory"),
+      legoDnsServers = "8.8.8.8:53"
+    )
+  )
+
+  val run = new Run(options)
+
+  test("Run should correctly map options") {
+    assertEquals(run.certDomains, "example.com www.example.com")
+    assertEquals(run.dnsServers, "8.8.8.8:53")
+    assertEquals(run.legoEmail, "test@example.com")
+    assertEquals(run.legoPath, Some("/tmp/lego"))
+    assertEquals(run.legoServer, Some("https://acme-staging-v02.api.letsencrypt.org/directory"))
+    assertEquals(run.dnsProvider, "test-provider")
+    assertEquals(run.cfApiToken, "test-token")
+    assertEquals(run.cfPollingInterval, "10")
+    assertEquals(run.cfPropagationTimeout, "200")
+    assertEquals(run.cfTtl, "60")
+  }
+
+  test("Run should have correct action name and args") {
+    assertEquals(run.actionName, "run")
+    assertEquals(run.actionArgs, Seq("run"))
+  }
+
+  test("Run.execute should return error when domains are empty") {
+    val emptyOptions = options.copy(certificate = Certificate(certDomains = ""))
+    val runEmpty     = new Run(emptyOptions)
+    val result       = runEmpty.execute()
+    assertEquals(result, Left(CertError.UnspecifiedError("", "No domains provided")))
+  }
+
+  test("Run.execute should return error when domains are whitespace only") {
+    val whitespaceOptions = options.copy(certificate = Certificate(certDomains = "   "))
+    val runWhitespace     = new Run(whitespaceOptions)
+    val result            = runWhitespace.execute()
+    assertEquals(result, Left(CertError.UnspecifiedError("", "No domains provided")))
+  }
+
+  test("Run.execute should handle process execution failure (Exception)") {
+    class RunThrows(options: RunOptions) extends Run(options) {
+      override protected def runCommand(command: Seq[String], env: Map[String, String]): os.CommandResult = {
+        throw new RuntimeException("Simulated process failure")
+      }
+    }
+
+    val runFailure = new RunThrows(options)
+    val result     = runFailure.execute()
+
+    assertEquals(
+      result,
+      Left(CertError.UnspecifiedError("run", "Exception: Simulated process failure"))
+    )
+  }
+
+  test("Run.execute should handle successful certificate issuance") {
+    class RunSuccess(options: RunOptions) extends Run(options) {
+      override protected def runCommand(command: Seq[String], env: Map[String, String]): os.CommandResult = {
+        os.CommandResult(0, Seq.empty, os.Source.fromString(""), os.Source.fromString("Server responded with a certificate."))
+      }
+    }
+
+    val runSuccess = new RunSuccess(options)
+    val result     = runSuccess.execute()
+
+    assertEquals(result, Right(CertOk.NewCertificate("example.com")))
+  }
+}


### PR DESCRIPTION
🎯 **What:** Addressed the missing test file for the `Run` class and fixed a critical bug in the base `LegoJob` class (duplicate `execute` method with incorrect return type) that was discovered during development.

📊 **Coverage:**
- Verified correct mapping of `RunOptions` to `Run` class properties.
- Confirmed `actionName` and `actionArgs` are correctly set for the "run" command.
- Tested `execute` method for:
  - Error handling when no domains are provided.
  - Successful certificate issuance (mocking process output).
  - Exception handling during process execution.

✨ **Result:** Improved the reliability and maintainability of the Let's Encrypt Scala script by providing test coverage for the `Run` action and fixing a core logic bug in the class hierarchy.

---
*PR created automatically by Jules for task [13688089965851405890](https://jules.google.com/task/13688089965851405890) started by @kuba86*